### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/Lib.v
+++ b/src/Lib.v
@@ -1,6 +1,6 @@
 From Coq Require Export List.
 From Coq Require Export Lia.
-From Coq Require Export Arith.Compare_dec.
+From Coq Require Export Compare_dec.
 From Coq Require Export Arith.
 
 From Classes Require Export Classes.


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
